### PR TITLE
add color for patch badge in mock overview

### DIFF
--- a/src/app/mocks/overview/overview-row.component.scss
+++ b/src/app/mocks/overview/overview-row.component.scss
@@ -50,6 +50,10 @@
       &-put {
         background: seagreen;
       }
+      
+      &-patch {
+        background: seagreen;
+      }
     }
   }
 }


### PR DESCRIPTION
Added a seagreen color for the patch badge. Right now it is white, which makes it basically invisible.