### PR TITLE
feat(mocks-overview): add badge colors

### DIFF
--- a/src/app/mocks/overview/overview-row.component.scss
+++ b/src/app/mocks/overview/overview-row.component.scss
@@ -34,6 +34,7 @@
       color: white;
       padding-top: 5px;
       margin-top: 2px;
+      background: #b1aeae;
 
       &-delete {
         background: crimson;
@@ -48,6 +49,10 @@
       }
 
       &-put {
+        background: seagreen;
+      }
+      
+      &-patch {
         background: seagreen;
       }
     }


### PR DESCRIPTION
When using a method that has no badge color defined, the badge will be invisible (white on white).

*added default grey color for undefined methods
*added a seagreen color for patch method